### PR TITLE
Multiple boards support in OpenOCD boot action method

### DIFF
--- a/doc/v2/actions-boot.rst
+++ b/doc/v2/actions-boot.rst
@@ -651,30 +651,6 @@ The ``pyocd`` boot method takes no arguments or parameters.
 
 .. _boot_method_jlink:
 
-
-.. index:: boot method minimal
-
-.. _boot_method_minimal:
-
-minimal
-=======
-
-The ``minimal`` method is used to power-on the :term:`DUT` and to let the
-:term:`DUT` boot without any interaction.
-
-.. code-block:: yaml
-
-    method: minimal
-    prompts:
-    - 'root@debian:~#'
-    - '/ #'
-
-.. note:: auto-login and transfer_overlay are both supported for this method.
-
-By default LAVA will reset the board power when executing this action. Users
-can skip this step by adding ``reset: false``. This can be useful when testing
-bootloader in interactive tests and then booting to the OS.
-
 jlink
 =====
 

--- a/doc/v2/actions-boot.rst
+++ b/doc/v2/actions-boot.rst
@@ -647,6 +647,46 @@ The ``pyocd`` boot method takes no arguments or parameters.
     timeout:
       minutes: 10
 
+.. index:: boot method jlink
+
+.. _boot_method_jlink:
+
+
+.. index:: boot method minimal
+
+.. _boot_method_minimal:
+
+minimal
+=======
+
+The ``minimal`` method is used to power-on the :term:`DUT` and to let the
+:term:`DUT` boot without any interaction.
+
+.. code-block:: yaml
+
+    method: minimal
+    prompts:
+    - 'root@debian:~#'
+    - '/ #'
+
+.. note:: auto-login and transfer_overlay are both supported for this method.
+
+By default LAVA will reset the board power when executing this action. Users
+can skip this step by adding ``reset: false``. This can be useful when testing
+bootloader in interactive tests and then booting to the OS.
+
+jlink
+=====
+
+The ``jlink`` boot method takes no arguments or parameters.
+
+.. code-block:: yaml
+
+ - boot:
+    method: jlink
+    timeout:
+      minutes: 10
+
 .. index:: boot method console
 
 .. _boot_method_console:

--- a/doc/v2/actions-boot.rst
+++ b/doc/v2/actions-boot.rst
@@ -600,6 +600,11 @@ from the location specified by ``openocd_script`` in the job definition, if
 a custom script file should be used instead of the one specified by the
 device type.
 
+``board_selection_cmd`` can be used in the device-type to specify a command to
+pass the board id/serial number to OpenOCD. See OpenOCD documentation for
+details on the command to set the serial number for the interface your
+device type is using.
+
 .. code-block:: yaml
 
  - boot:

--- a/lava_common/schemas/boot/jlink.py
+++ b/lava_common/schemas/boot/jlink.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018 Linaro Limited
+#
+# Author: Rémi Duraffort <remi.duraffort@linaro.org>
+#
+# This file is part of LAVA.
+#
+# LAVA is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+from voluptuous import Msg, Required
+
+from lava_common.schemas import boot
+
+
+def schema():
+    base = {Required("method"): Msg("jlink", "'method' should be 'jlink'")}
+    return {**boot.schema(), **base}

--- a/lava_common/schemas/boot/jlink.py
+++ b/lava_common/schemas/boot/jlink.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2018 Linaro Limited
+# Copyright (C) 2019 Linaro Limited
 #
-# Author: Rémi Duraffort <remi.duraffort@linaro.org>
+# Author: Andrei Gansari <andrei.gansari@linaro.org>
 #
 # This file is part of LAVA.
 #

--- a/lava_dispatcher/actions/boot/cmsis_dap.py
+++ b/lava_dispatcher/actions/boot/cmsis_dap.py
@@ -152,6 +152,9 @@ class FlashCMSISAction(Action):
         for f in self.filelist:
             self.logger.debug("Copying %s to %s", f, dstdir)
             shutil.copy2(f, dstdir)
+        # sync
+        sync_command = "sync %s" % dstdir
+        self.run_command(sync_command.split(" "), allow_silent=True)
         # umount
         umount_command = "umount %s" % self.usb_mass_device
         self.run_command(umount_command.split(" "), allow_silent=True)

--- a/lava_dispatcher/actions/boot/jlink.py
+++ b/lava_dispatcher/actions/boot/jlink.py
@@ -31,6 +31,7 @@ from lava_dispatcher.utils.udev import WaitDeviceBoardID
 
 # import subprocess
 
+
 class JLink(Boot):
 
     compatibility = 4  # FIXME: change this to 5 and update test cases
@@ -119,6 +120,7 @@ class FlashJLinkAction(Action):
         super().validate()
         boot = self.job.device["actions"]["boot"]["methods"]["jlink"]
         jlink_binary = boot["parameters"]["command"]
+        load_address = boot["parameters"]["address"]
         # binary = which(jlink_binary)
         self.logger.info(self.filename_version(jlink_binary))
         # self.logger.info(self.run_command("pwd"))
@@ -155,9 +157,9 @@ class FlashJLinkAction(Action):
             #     binary_image = action_arg
 
             lines.append('loadfile {} 0x{:x}'.format(binary_image,
-                         0x00000000))
+                         load_address))
             lines.append('verifybin {} 0x{:x}'.format(binary_image,
-                         0x00000000))
+                         load_address))
             lines.append('r')   # Restart the CPU
             lines.append('qc')  # Close the connection and quit
 

--- a/lava_dispatcher/actions/boot/jlink.py
+++ b/lava_dispatcher/actions/boot/jlink.py
@@ -1,6 +1,6 @@
-# Copyright (C) 2016 Linaro Limited
+# Copyright (C) 2019 Linaro Limited
 #
-# Author: Tyler Baker <tyler.baker@linaro.org>
+# Author: Andrei Gansari <andrei.gansari@linaro.org>
 #
 # This file is part of LAVA Dispatcher.
 #
@@ -18,23 +18,15 @@
 # along
 # with this program; if not, see <http://www.gnu.org/licenses>.
 
-# from lava_common.utils import debian_filename_version
 from lava_dispatcher.action import Pipeline, Action, JobError
 from lava_dispatcher.logical import Boot, RetryAction
 from lava_dispatcher.actions.boot import BootAction
 from lava_dispatcher.connections.serial import ConnectDevice
-# from lava_dispatcher.utils.shell import which
-# from lava_dispatcher.utils.strings import substitute
 from lava_dispatcher.power import ResetDevice
 from lava_dispatcher.utils.udev import WaitDeviceBoardID
-# from lava_common.exceptions import InfrastructureError
-
-# import subprocess
 
 
 class JLink(Boot):
-
-    compatibility = 4  # FIXME: change this to 5 and update test cases
 
     def __init__(self, parent, parameters):
         super().__init__(parent)
@@ -94,23 +86,6 @@ class FlashJLinkAction(Action):
     description = "flash jlink to boot the image"
     summary = "flash jlink to boot the image"
 
-    @staticmethod
-    def filename_version(binary):
-        # if binary is not absolute, fail.
-        msg = "Unable to retrieve version of %s" % binary
-        ver_str = "TODO later - read version"
-        # try:
-        #     ver_str = (
-        #         subprocess.check_output([binary, "-version"])
-        #         .decode("utf-8", errors="replace")
-        #     )
-        #     self.logger.info('version = ', binary)
-        #     if not ver_str:
-        #         raise InfrastructureError(msg+" 1 "+binary)
-        # except subprocess.CalledProcessError:
-        #     raise InfrastructureError(msg+" 2 "+ver_str)
-        return "%s, version %s" % (binary, ver_str)
-
     def __init__(self):
         super().__init__()
         self.base_command = []
@@ -121,15 +96,11 @@ class FlashJLinkAction(Action):
         boot = self.job.device["actions"]["boot"]["methods"]["jlink"]
         jlink_binary = boot["parameters"]["command"]
         load_address = boot["parameters"]["address"]
-        # binary = which(jlink_binary)
-        self.logger.info(self.filename_version(jlink_binary))
-        # self.logger.info(self.run_command("pwd"))
         self.base_command = [jlink_binary]
         self.base_command.extend(boot["parameters"].get("options", []))
         if self.job.device["board_id"] == "0000000000":
             self.errors = "[JLink] board_id unset"
         substitutions = {}
-        # self.base_command.extend(["--board", self.job.device["board_id"]])
         for action in self.get_namespace_keys("download-action"):
             jlink_full_command = []
             image_arg = self.get_namespace_data(
@@ -147,15 +118,6 @@ class FlashJLinkAction(Action):
             lines.append('erase')  # Erase all flash sectors
             lines.append('sleep 500')
 
-            # if image_arg:
-            #     if not isinstance(image_arg, str):
-            #         self.errors = "image_arg is not a string (try quoting it)"
-            #         continue
-            #     substitutions["{%s}" % action] = action_arg
-            #     binary_image = substitute([image_arg]
-            # else:
-            #     binary_image = action_arg
-
             lines.append('loadfile {} 0x{:x}'.format(binary_image,
                          load_address))
             lines.append('verifybin {} 0x{:x}'.format(binary_image,
@@ -172,7 +134,7 @@ class FlashJLinkAction(Action):
 
             self.exec_list.append(jlink_full_command)
         if not self.exec_list:
-            self.errors = "No JLink command to execute"
+            self.errors = "No JLinkExe command to execute"
 
     def run(self, connection, max_end_time):
         connection = self.get_namespace_data(

--- a/lava_dispatcher/actions/boot/jlink.py
+++ b/lava_dispatcher/actions/boot/jlink.py
@@ -100,6 +100,9 @@ class FlashJLinkAction(Action):
         self.base_command.extend(boot["parameters"].get("options", []))
         if self.job.device["board_id"] == "0000000000":
             self.errors = "[JLink] board_id unset"
+        #select the board with the coorect serial number
+        self.base_command.extend("-SelectEmuBySN ")
+        self.base_command.extend(self.job.device["board_id"])
         substitutions = {}
         for action in self.get_namespace_keys("download-action"):
             jlink_full_command = []

--- a/lava_dispatcher/actions/boot/jlink.py
+++ b/lava_dispatcher/actions/boot/jlink.py
@@ -1,0 +1,188 @@
+# Copyright (C) 2016 Linaro Limited
+#
+# Author: Tyler Baker <tyler.baker@linaro.org>
+#
+# This file is part of LAVA Dispatcher.
+#
+# LAVA Dispatcher is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA Dispatcher is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+# from lava_common.utils import debian_filename_version
+from lava_dispatcher.action import Pipeline, Action, JobError
+from lava_dispatcher.logical import Boot, RetryAction
+from lava_dispatcher.actions.boot import BootAction
+from lava_dispatcher.connections.serial import ConnectDevice
+# from lava_dispatcher.utils.shell import which
+# from lava_dispatcher.utils.strings import substitute
+from lava_dispatcher.power import ResetDevice
+from lava_dispatcher.utils.udev import WaitDeviceBoardID
+# from lava_common.exceptions import InfrastructureError
+
+# import subprocess
+
+class JLink(Boot):
+
+    compatibility = 4  # FIXME: change this to 5 and update test cases
+
+    def __init__(self, parent, parameters):
+        super().__init__(parent)
+        self.action = BootJLink()
+        self.action.section = self.action_type
+        self.action.job = self.job
+        parent.add_action(self.action, parameters)
+
+    @classmethod
+    def accepts(cls, device, parameters):
+        if "jlink" not in device["actions"]["boot"]["methods"]:
+            return False, '"jlink" was not in the device configuration boot methods'
+        if "method" not in parameters:
+            return False, '"method" was not in parameters'
+        if parameters["method"] != "jlink":
+            return False, '"method" was not "jlink"'
+        if "board_id" not in device:
+            return False, '"board_id" is not in the device configuration'
+        return True, "accepted"
+
+
+class BootJLink(BootAction):
+
+    name = "boot-jlink-image"
+    description = "boot jlink image with retry"
+    summary = "boot jlink image with retry"
+
+    def populate(self, parameters):
+        self.internal_pipeline = Pipeline(
+            parent=self, job=self.job, parameters=parameters
+        )
+        self.internal_pipeline.add_action(BootJLinkRetry())
+
+
+class BootJLinkRetry(RetryAction):
+
+    name = "boot-jlink-image"
+    description = "boot jlink image using the command line interface"
+    summary = "boot jlink image"
+
+    def populate(self, parameters):
+        self.internal_pipeline = Pipeline(
+            parent=self, job=self.job, parameters=parameters
+        )
+        if self.job.device.hard_reset_command:
+            self.internal_pipeline.add_action(ResetDevice())
+            self.internal_pipeline.add_action(
+                WaitDeviceBoardID(self.job.device.get("board_id"))
+            )
+        self.internal_pipeline.add_action(FlashJLinkAction())
+        self.internal_pipeline.add_action(ConnectDevice())
+
+
+class FlashJLinkAction(Action):
+
+    name = "flash-jlink"
+    description = "flash jlink to boot the image"
+    summary = "flash jlink to boot the image"
+
+    @staticmethod
+    def filename_version(binary):
+        # if binary is not absolute, fail.
+        msg = "Unable to retrieve version of %s" % binary
+        ver_str = "TODO later - read version"
+        # try:
+        #     ver_str = (
+        #         subprocess.check_output([binary, "-version"])
+        #         .decode("utf-8", errors="replace")
+        #     )
+        #     self.logger.info('version = ', binary)
+        #     if not ver_str:
+        #         raise InfrastructureError(msg+" 1 "+binary)
+        # except subprocess.CalledProcessError:
+        #     raise InfrastructureError(msg+" 2 "+ver_str)
+        return "%s, version %s" % (binary, ver_str)
+
+    def __init__(self):
+        super().__init__()
+        self.base_command = []
+        self.exec_list = []
+
+    def validate(self):
+        super().validate()
+        boot = self.job.device["actions"]["boot"]["methods"]["jlink"]
+        jlink_binary = boot["parameters"]["command"]
+        # binary = which(jlink_binary)
+        self.logger.info(self.filename_version(jlink_binary))
+        # self.logger.info(self.run_command("pwd"))
+        self.base_command = [jlink_binary]
+        self.base_command.extend(boot["parameters"].get("options", []))
+        if self.job.device["board_id"] == "0000000000":
+            self.errors = "[JLink] board_id unset"
+        substitutions = {}
+        # self.base_command.extend(["--board", self.job.device["board_id"]])
+        for action in self.get_namespace_keys("download-action"):
+            jlink_full_command = []
+            image_arg = self.get_namespace_data(
+                action="download-action", label=action, key="image_arg"
+            )
+            action_arg = self.get_namespace_data(
+                action="download-action", label=action, key="file"
+            )
+            binary_image = action_arg
+
+            jlink_full_command.extend(self.base_command)
+
+            lines = ['r']          # Reset and halt the target
+            lines.append('h')      # Reset and halt the target
+            lines.append('erase')  # Erase all flash sectors
+            lines.append('sleep 500')
+
+            # if image_arg:
+            #     if not isinstance(image_arg, str):
+            #         self.errors = "image_arg is not a string (try quoting it)"
+            #         continue
+            #     substitutions["{%s}" % action] = action_arg
+            #     binary_image = substitute([image_arg]
+            # else:
+            #     binary_image = action_arg
+
+            lines.append('loadfile {} 0x{:x}'.format(binary_image,
+                         0x00000000))
+            lines.append('verifybin {} 0x{:x}'.format(binary_image,
+                         0x00000000))
+            lines.append('r')   # Restart the CPU
+            lines.append('qc')  # Close the connection and quit
+
+            self.logger.info("JLink command file: \n" + ''.join(lines))
+
+            fname = 'cmd.jlink'
+            with open(fname, 'wb') as f:
+                f.writelines(bytes(line + '\n', 'utf-8') for line in lines)
+                f.close()
+
+            self.exec_list.append(jlink_full_command)
+        if not self.exec_list:
+            self.errors = "No JLink command to execute"
+
+    def run(self, connection, max_end_time):
+        connection = self.get_namespace_data(
+            action="shared", label="shared", key="connection", deepcopy=False
+        )
+        connection = super().run(connection, max_end_time)
+        for jlink_command in self.exec_list:
+            jlink = " ".join(jlink_command)
+            self.logger.info("JLink command: %s", jlink)
+            if not self.run_command(jlink.split(" ")):
+                raise JobError("%s command failed" % (jlink.split(" ")))
+        self.set_namespace_data(
+            action="shared", label="shared", key="connection", value=connection
+        )
+        return connection

--- a/lava_dispatcher/actions/boot/openocd.py
+++ b/lava_dispatcher/actions/boot/openocd.py
@@ -106,6 +106,7 @@ class FlashOpenOCDAction(Action):
         )
         self.base_command = [openocd_binary]
         job_cfg_file = ""
+        self.logger.info("Board ID: %s", self.job.device["board_id"])
 
         # Build the substitutions dictionary and set cfg script based on
         # job definition
@@ -132,6 +133,17 @@ class FlashOpenOCDAction(Action):
         if job_cfg_file is "":
             for item in boot["parameters"]["options"].get("file", []):
                 self.base_command.extend(["-f", item])
+
+        if "board_selection_cmd" in boot.keys():
+            # Add an extra tcl script to select the board to be used
+            temp_dir = self.mkdtemp()
+            board_selection_cfg = temp_dir + "/board_selection.cfg"
+            board_select_cmd = boot["board_selection_cmd"]
+            f = open(board_selection_cfg, "w+")
+            f.write(board_select_cmd)
+            f.close()
+            self.base_command.extend(["-f", board_selection_cfg])
+
         debug = boot["parameters"]["options"]["debug"]
         self.base_command.extend(["-d" + str(debug)])
         for item in boot["parameters"]["options"].get("search", []):

--- a/lava_dispatcher/actions/boot/strategies.py
+++ b/lava_dispatcher/actions/boot/strategies.py
@@ -39,6 +39,7 @@ from lava_dispatcher.actions.boot.lxc import BootLxc
 from lava_dispatcher.actions.boot.minimal import Minimal
 from lava_dispatcher.actions.boot.openocd import OpenOCD
 from lava_dispatcher.actions.boot.pyocd import PyOCD
+from lava_dispatcher.actions.boot.jlink import JLink
 from lava_dispatcher.actions.boot.qemu import BootQEMU
 from lava_dispatcher.actions.boot.ssh import SshLogin, Schroot
 from lava_dispatcher.actions.boot.u_boot import UBoot

--- a/lava_dispatcher/tests/pipeline_refs/jlink-with-power.yaml
+++ b/lava_dispatcher/tests/pipeline_refs/jlink-with-power.yaml
@@ -1,0 +1,29 @@
+- class: actions.deploy.image.DeployImagesAction
+  name: deployimages
+  pipeline:
+  - class: actions.deploy.download.DownloaderAction
+    name: download-retry
+    pipeline:
+    - {class: actions.deploy.download.HttpDownloadAction, name: http-download}
+- class: actions.boot.jlink.BootJLink
+  name: boot-jlink-image
+  pipeline:
+  - class: actions.boot.jlink.BootJLinkRetry
+    name: boot-jlink-image
+    pipeline:
+    - class: power.ResetDevice
+      name: reset-device
+      pipeline:
+      - {class: power.PDUReboot, name: pdu-reboot}
+    - {class: utils.udev.WaitDeviceBoardID, name: wait-device-boardid}
+    - {class: actions.boot.jlink.FlashJLinkAction, name: flash-jlink}
+    - {class: connections.serial.ConnectDevice, name: connect-device}
+- class: actions.test.monitor.TestMonitorRetry
+  name: lava-test-monitor-retry
+  pipeline:
+  - {class: actions.test.monitor.TestMonitorAction, name: lava-test-monitor}
+- class: power.FinalizeAction
+  name: finalize
+  pipeline:
+  - {class: power.PowerOff, name: power-off}
+  - {class: power.ReadFeedback, name: read-feedback}

--- a/lava_dispatcher/tests/pipeline_refs/jlink.yaml
+++ b/lava_dispatcher/tests/pipeline_refs/jlink.yaml
@@ -1,0 +1,24 @@
+- class: actions.deploy.image.DeployImagesAction
+  name: deployimages
+  pipeline:
+  - class: actions.deploy.download.DownloaderAction
+    name: download-retry
+    pipeline:
+    - {class: actions.deploy.download.HttpDownloadAction, name: http-download}
+- class: actions.boot.jlink.BootJLink
+  name: boot-jlink-image
+  pipeline:
+  - class: actions.boot.jlink.BootJLinkRetry
+    name: boot-jlink-image
+    pipeline:
+    - {class: actions.boot.jlink.FlashJLinkAction, name: flash-jlink}
+    - {class: connections.serial.ConnectDevice, name: connect-device}
+- class: actions.test.monitor.TestMonitorRetry
+  name: lava-test-monitor-retry
+  pipeline:
+  - {class: actions.test.monitor.TestMonitorAction, name: lava-test-monitor}
+- class: power.FinalizeAction
+  name: finalize
+  pipeline:
+  - {class: power.PowerOff, name: power-off}
+  - {class: power.ReadFeedback, name: read-feedback}

--- a/lava_dispatcher/tests/test_jlink.py
+++ b/lava_dispatcher/tests/test_jlink.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2017 Linaro Limited
+#
+# Author: Matthew Hart <matthew.hart@linaro.org>
+#
+# This file is part of LAVA Dispatcher.
+#
+# LAVA Dispatcher is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# LAVA Dispatcher is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along
+# with this program; if not, see <http://www.gnu.org/licenses>.
+
+
+import unittest
+from lava_dispatcher.tests.test_basic import Factory, StdoutTestCase
+from lava_dispatcher.tests.utils import infrastructure_error
+
+
+class JLinkFactory(Factory):  # pylint: disable=too-few-public-methods
+    """
+    Not Model based, this is not a Django factory.
+    Factory objects are dispatcher based classes, independent
+    of any database objects.
+    """
+
+    @unittest.skipIf(
+        infrastructure_error("jlink-flashtool"), "jlink-flashtool not installed"
+    )
+    def create_k64f_job(self, filename):
+        return self.create_job("frdm-k64f-01.jinja2", filename)
+
+    @unittest.skipIf(
+        infrastructure_error("jlink-flashtool"), "jlink-flashtool not installed"
+    )
+    def create_k64f_job_with_power(self, filename):  # pylint: disable=no-self-use
+        return self.create_job("frdm-k64f-power-01.jinja2", filename)
+
+
+class TestJLinkAction(StdoutTestCase):  # pylint: disable=too-many-public-methods
+    def test_jlink_pipeline(self):
+        factory = JLinkFactory()
+        job = factory.create_k64f_job(
+            "sample_jobs/zephyr-frdm-k64f-jlink-test-kernel-common.yaml"
+        )
+        job.validate()
+        description_ref = self.pipeline_reference("jlink.yaml", job=job)
+        self.assertEqual(description_ref, job.pipeline.describe(False))
+        job = factory.create_k64f_job_with_power(
+            "sample_jobs/zephyr-frdm-k64f-jlink-test-kernel-common.yaml"
+        )
+        job.validate()
+        description_ref = self.pipeline_reference("jlink-with-power.yaml", job=job)
+        self.assertEqual(description_ref, job.pipeline.describe(False))

--- a/lava_dispatcher/tests/test_jlink.py
+++ b/lava_dispatcher/tests/test_jlink.py
@@ -1,6 +1,6 @@
-# Copyright (C) 2017 Linaro Limited
+# Copyright (C) 2019 Linaro Limited
 #
-# Author: Matthew Hart <matthew.hart@linaro.org>
+# Author: Andrei Gansari <andrei.gansari@linaro.org>
 #
 # This file is part of LAVA Dispatcher.
 #

--- a/lava_scheduler_app/tests/device-types/cc13x2-launchpad.jinja2
+++ b/lava_scheduler_app/tests/device-types/cc13x2-launchpad.jinja2
@@ -1,0 +1,42 @@
+{# device_type: cc13x2-launchpad #}
+{% extends 'base.jinja2' %}
+{% block body %}
+board_id: '{{ board_id|default('00000000') }}'
+usb_vendor_id: '0451'
+usb_product_id: 'bef3'
+usb_sleep: {{ usb_sleep|default(10) }}
+
+actions:
+  deploy:
+    methods:
+      image:
+        parameters:
+
+  boot:
+    connections:
+      serial:
+    methods:
+      openocd:
+        parameters:
+          command:
+            # Can set 'openocd_bin_override' in device dictionary to
+            # override location of OpenOCD executable to point to TI OpenOCD
+            # if necessary
+            {{ openocd_bin_override|default('openocd') }}
+          options:
+            file:
+              - board/ti_cc13x2_launchpad.cfg
+            # Set 'openocd_scripts_dir_override' in device dictionary to
+            # point to TI OpenOCD scripts if necessary
+            search: [{{ openocd_scripts_dir_override }}]
+            command:
+              - init
+              - targets
+              - 'reset halt'
+              - 'flash write_image erase {BINARY}'
+              - 'reset halt'
+              - 'verify_image {BINARY}'
+              - 'reset run'
+              - shutdown
+            debug: 2
+{% endblock body %}

--- a/lava_scheduler_app/tests/device-types/cc13x2-launchpad.jinja2
+++ b/lava_scheduler_app/tests/device-types/cc13x2-launchpad.jinja2
@@ -17,6 +17,8 @@ actions:
       serial:
     methods:
       openocd:
+        board_selection_cmd:
+            xds110_serial {{ board_id|default('00000000') }}
         parameters:
           command:
             # Can set 'openocd_bin_override' in device dictionary to
@@ -30,6 +32,7 @@ actions:
             # point to TI OpenOCD scripts if necessary
             search: [{{ openocd_scripts_dir_override }}]
             command:
+              - gdb_port pipe; log_output openocd.log
               - init
               - targets
               - 'reset halt'

--- a/lava_scheduler_app/tests/device-types/cc3220SF.jinja2
+++ b/lava_scheduler_app/tests/device-types/cc3220SF.jinja2
@@ -17,6 +17,8 @@ actions:
       serial:
     methods:
       openocd:
+        board_selection_cmd:
+            xds110_serial {{ board_id|default('00000000') }}
         parameters:
           command:
             # Can set 'openocd_bin_override' in device dictionary to
@@ -30,6 +32,7 @@ actions:
             # point to TI OpenOCD scripts if necessary
             search: [{{ openocd_scripts_dir_override }}]
             command:
+              - gdb_port pipe; log_output openocd.log
               - init
               - targets
               - 'reset halt'

--- a/lava_scheduler_app/tests/device-types/frdm-k64f.jinja2
+++ b/lava_scheduler_app/tests/device-types/frdm-k64f.jinja2
@@ -33,4 +33,14 @@ actions:
         parameters:
           usb_mass_device: '{{ usb_mass_device|default('/notset') }}'
           resets_after_flash: {{ resets_after_flash|default(True) }}
+      jlink:
+        parameters:
+          command:
+            JLinkExe
+          options:
+          - -device MK64FN1M0xxx12
+          - -if SWD
+          - -speed 4000
+          - -autoconnect 1
+          - -CommanderScript cmd.jlink
 {% endblock body -%}

--- a/lava_scheduler_app/tests/device-types/frdm-k64f.jinja2
+++ b/lava_scheduler_app/tests/device-types/frdm-k64f.jinja2
@@ -37,6 +37,8 @@ actions:
         parameters:
           command:
             JLinkExe
+          address:
+            0x00000000
           options:
           - -device MK64FN1M0xxx12
           - -if SWD

--- a/lava_scheduler_app/tests/device-types/frdm-k64f.jinja2
+++ b/lava_scheduler_app/tests/device-types/frdm-k64f.jinja2
@@ -40,9 +40,9 @@ actions:
           address:
             0x00000000
           options:
-          - -device MK64FN1M0xxx12
-          - -if SWD
-          - -speed 4000
-          - -autoconnect 1
-          - -CommanderScript cmd.jlink
+          - "-device MK64FN1M0xxx12"
+          - "-if SWD"
+          - "-speed 4000"
+          - "-autoconnect 1"
+          - "-CommanderScript cmd.jlink"
 {% endblock body -%}


### PR DESCRIPTION
We pass the board id to OpenOCD via a temporary configuration file created
on the fly, so that each board can be identified.

Device types are updated to provide the appropriate board selection
command to OpenOCD, and to disable the gdb port to avoid collisions when
running concurrent jobs on multiple boards.